### PR TITLE
Use a page_action on facebook urls

### DIFF
--- a/Chrome Extension/js/background.js
+++ b/Chrome Extension/js/background.js
@@ -1,0 +1,6 @@
+chrome.tabs.onUpdated.addListener(function(id, info) {
+    var fbre = /facebook/;
+    if (fbre.test(info.url)) {
+        chrome.pageAction.show(id);
+    }
+});

--- a/Chrome Extension/manifest.json
+++ b/Chrome Extension/manifest.json
@@ -20,11 +20,13 @@
 
     "homepage_url" : "http://www.kortaggio.com/",
 
-    "browser_action": {
+    "page_action": {
         "default_icon": "img/icon.png",
         "default_title" : "Hide Facebook Post Likes (Beta)",
         "default_popup": "popup.html"
     },
+
+    "background": {"scripts": ["js/background.js"]},
 
     "update_url": "http://clients2.google.com/service/update2/crx"
 }


### PR DESCRIPTION
Shows the icon in the address bar instead, and only on facebook urls, since it doesn't have functionality (yet?) on other urls.
